### PR TITLE
use Unified Dyes on_dig where needed

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -74,6 +74,7 @@ minetest.register_node("castle_tapestries:tapestry", {
 		wall_side = {-0.5,-0.5,0.4375,0.5,1.5,0.5},
 	},
 	after_place_node = unifieddyes.fix_rotation_nsew,
+	on_dig = unifieddyes.on_dig,
 	on_rotate = unifieddyes.fix_after_screwdriver_nsew
 })
 
@@ -95,6 +96,7 @@ minetest.register_node("castle_tapestries:tapestry_long", {
 		wall_side = {-0.5,-0.5,0.4375,0.5,2.5,0.5},
 	},
 	after_place_node = unifieddyes.fix_rotation_nsew,
+	on_dig = unifieddyes.on_dig,
 	on_rotate = unifieddyes.fix_after_screwdriver_nsew
 })
 
@@ -116,6 +118,7 @@ minetest.register_node("castle_tapestries:tapestry_very_long", {
 		wall_side = {-0.5,-0.5,0.4375,0.5,3.5,0.5},
 	},
 	after_place_node = unifieddyes.fix_rotation_nsew,
+	on_dig = unifieddyes.on_dig,
 	on_rotate = unifieddyes.fix_after_screwdriver_nsew
 })
 


### PR DESCRIPTION
prevents creating look-alike/excess itemstacks on-dig of a colored item
requires UD commit 9ff40a7f or later