### PR TITLE
Update depends

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -13,6 +13,8 @@ else
 
 end
 
+-- cottages support
+local use_cottages = minetest.get_modpath("cottages")
 
 local tapestry = {}
 
@@ -144,20 +146,8 @@ minetest.register_craft({
 
 minetest.register_craft({
 	type = "shapeless",
-	output = 'castle_tapestries:tapestry',
-	recipe = {'cottages:wool', 'default:stick'},
-})
-
-minetest.register_craft({
-	type = "shapeless",
 	output = 'castle_tapestries:tapestry_long',
 	recipe = {'wool:white', 'castle_tapestries:tapestry'},
-})
-
-minetest.register_craft({
-	type = "shapeless",
-	output = 'castle_tapestries:tapestry_long',
-	recipe = {'cottages:wool', 'castle_tapestries:tapestry'},
 })
 
 minetest.register_craft({
@@ -166,11 +156,25 @@ minetest.register_craft({
 	recipe = {'wool:white', 'castle_tapestries:tapestry_long'},
 })
 
-minetest.register_craft({
-	type = "shapeless",
-	output = 'castle_tapestries:tapestry_very_long',
-	recipe = {'cottages:wool', 'castle_tapestries:tapestry_long'},
-})
+if use_cottages then
+	minetest.register_craft({
+		type = "shapeless",
+		output = 'castle_tapestries:tapestry',
+		recipe = {'cottages:wool', 'default:stick'},
+	})
+
+
+	minetest.register_craft({
+		type = "shapeless",
+		output = 'castle_tapestries:tapestry_long',
+		recipe = {'cottages:wool', 'castle_tapestries:tapestry'},
+	})
+	minetest.register_craft({
+		type = "shapeless",
+		output = 'castle_tapestries:tapestry_very_long',
+		recipe = {'cottages:wool', 'castle_tapestries:tapestry_long'},
+	})
+end
 
 
 unifieddyes.register_color_craft({

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name = castle_tapestries
-depends = default, unifieddyes
-optional_depends = intllib
+depends = default, unifieddyes, wool
+optional_depends = intllib, cottages
 description = This is a mod for creating medieval tapestries, as found in castles.


### PR DESCRIPTION
I added `wool` in depends and `cottages` in optional_depends.
Craft using `cottages`’s items are now registered only when `cottages`
is loaded.