### PR TITLE
remove duplicated recipes

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,9 +1,6 @@
 -- Used for localization, choose either built-in or intllib.
 local S = minetest.get_translator("castle_tapestries")
 
--- cottages support
-local use_cottages = minetest.get_modpath("cottages")
-
 local tapestry = {}
 
 minetest.register_alias("castle:tapestry_top", "castle_tapestries:tapestry_top")
@@ -161,26 +158,6 @@ minetest.register_craft({
 	output = 'castle_tapestries:tapestry_very_long',
 	recipe = {'wool:white', 'castle_tapestries:tapestry_long'},
 })
-
-if use_cottages then
-	minetest.register_craft({
-		type = "shapeless",
-		output = 'castle_tapestries:tapestry',
-		recipe = {'cottages:wool', 'default:stick'},
-	})
-
-
-	minetest.register_craft({
-		type = "shapeless",
-		output = 'castle_tapestries:tapestry_long',
-		recipe = {'cottages:wool', 'castle_tapestries:tapestry'},
-	})
-	minetest.register_craft({
-		type = "shapeless",
-		output = 'castle_tapestries:tapestry_very_long',
-		recipe = {'cottages:wool', 'castle_tapestries:tapestry_long'},
-	})
-end
 
 
 unifieddyes.register_color_craft({

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,3 @@
 name = castle_tapestries
 depends = default, unifieddyes, wool
-optional_depends = cottages
 description = This is a mod for creating medieval tapestries, as found in castles.


### PR DESCRIPTION
if `wool:white` is present (which is always the case since this mod depends on wool) , `cottages:wool` is just an alias...
So the "cottages support" just creates duplicated recipes

It might not always have been like that, but it's like that on every version/fork/rewrite I checked:
https://github.com/Sokomine/cottages/blob/ab7f7e107afd175522459f10991c8c746dc95374/nodes_historic.lua#L286

- https://github.com/mt-mods/cottages/blob/fdf149640157435223f4810322eb16c1c98056d6/nodes_historic.lua#L183
- https://github.com/h-v-smacker/cottages/blob/4e094c020f000905673a54d91d65a9c763871396/nodes_historic.lua#L167
- https://github.com/C-C-Minetest-Server/cottages/blob/4b5ee6a9978183c9d051c151a777c41c9b521407/src/nodes_historic.lua#L171
- https://github.com/BlockySurvival/cottages/blob/c1600d5577733fae5ebc99ac75ad4db7ec056a9d/nodes_historic.lua#L181